### PR TITLE
Auto-light candles in PostEntitySpawn

### DIFF
--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -4382,6 +4382,16 @@ namespace Oxide.Plugins
                     }, 2);
                 }
 
+                var candle = Entity as Candle;
+                if (candle != null)
+                {
+                    candle.SetFlag(BaseEntity.Flags.On, true);
+                    candle.CancelInvoke(candle.Burn);
+
+                    // Disallow extinguishing.
+                    candle.SetFlag(BaseEntity.Flags.Busy, true);
+                }
+
                 if (EntityData.Scale != 1 || Entity.GetParentEntity() is SphereEntity)
                 {
                     UpdateScale();


### PR DESCRIPTION
As advised here https://umod.org/community/monument-addons/42080-candles-not-lit

I added extra 'busy' flag to prevent players extinguishing candles