### PR TITLE
Telephone naming automation

### DIFF
--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -4491,7 +4491,7 @@ namespace Oxide.Plugins
                     TelephoneManager.RegisterTelephone(telephone.Controller);
                 }
 
-                    if (EntityData.Scale != 1 || Entity.GetParentEntity() is SphereEntity)
+                if (EntityData.Scale != 1 || Entity.GetParentEntity() is SphereEntity)
                 {
                     UpdateScale();
                 }

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -4483,6 +4483,15 @@ namespace Oxide.Plugins
                         phoneName = "Underwater Lab " + gridCoodr + roomName;
                     }
 
+                    var dynamicMonument = Monument as DynamicMonument;
+                    if (dynamicMonument != null)
+                    {
+                        if (dynamicMonument.RootEntity.ShortPrefabName == "cargoshiptest")
+                        {
+                            phoneName = "Cargo Ship " + dynamicMonument.EntityId;
+                        }
+                    }
+
                     if (phoneName != null)
                         telephone.Controller.PhoneName = phoneName;
                     else 


### PR DESCRIPTION
#29 

**Monuments**
 - if there is `displayPhrase` in `MonumentInfo`, show it as telephone name (**Abandoned Cabins**)
   - some **difference** in certain vanilla telephone vs landmark name (Satellite Dish Array vs **Satellite Dish**)
 - append grid coords if multiple instances of same monument (**Substation G12**)
 - when there is no `displayPhrase` in `MonumentInfo` (cave_large_sewers_hard), name will be just `telephone.GetDisplayName()`+ coord (**Telephone G12**)

**Freight Transit Line**
 - Utilizing aliases + grid coord with FTL prefix
   - **FTL Train Station G12**
   - **FTL Large Intersection F23**
   - **FTL Corner Tunnel R7**

**Underwater Labs**
 - I couldn't figure how to get "Underwater Lab" string from game, so I hardcoded it for now
 - Underwater Lab + grid coord + level index + room type + room index
   - **Underwater Lab X1 L4 Room 1**
   - **Underwater Lab X1 L1 Corridor 7**
  
I am not sure if `DoServerDestroy()` is called on `Telephone` instance when unloading MA. If not, we should add `TelephoneManager.DeregisterTelephone(phoneController)` to `PreEntityKill()`

I feel like code needs some improvements, but im pretty happy with functional result
