### PR TITLE
draft for telephone naming automation

### DIFF
--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -3675,32 +3675,32 @@ namespace Oxide.Plugins
 
             private static readonly Regex SplitCamelCaseRegex = new Regex("([a-z])([A-Z])", RegexOptions.Compiled);
 
-            public static void NameTelephone(Telephone telephone, SingleEntityAdapter adapter, MonumentAddons plugin) 
+            public static void NameTelephone(Telephone telephone, BaseMonument monument, Vector3 position, MonumentAddons plugin) 
             {
                 string phoneName = null;
 
-                var monumentInfo = adapter.Monument.Object as MonumentInfo;
+                var monumentInfo = monument.Object as MonumentInfo;
                 if (monumentInfo != null && !string.IsNullOrEmpty(monumentInfo.displayPhrase.translated))
                 {
                     phoneName = monumentInfo.displayPhrase.translated;
 
-                    if (ShouldAppendCoordinate(adapter.Monument.ShortName, plugin))
-                        phoneName += $" {PhoneController.PositionToGridCoord(adapter.Position)}";
+                    if (ShouldAppendCoordinate(monument.ShortName, plugin))
+                        phoneName += $" {PhoneController.PositionToGridCoord(position)}";
                 }
 
-                var dungeonGridCell = adapter.Monument.Object as DungeonGridCell;
-                if (dungeonGridCell != null && !string.IsNullOrEmpty(adapter.Monument.Alias))
+                var dungeonGridCell = monument.Object as DungeonGridCell;
+                if (dungeonGridCell != null && !string.IsNullOrEmpty(monument.Alias))
                 {
-                    phoneName = GetFTLPhoneName(adapter.Monument.Alias, dungeonGridCell, adapter, plugin);
+                    phoneName = GetFTLPhoneName(monument.Alias, dungeonGridCell, monument, position, plugin);
                 }
 
-                var dungeonBaseLink = adapter.Monument.Object as DungeonBaseLink;
+                var dungeonBaseLink = monument.Object as DungeonBaseLink;
                 if (dungeonBaseLink != null)
                 {
-                    phoneName = GetUnderwaterLabPhoneName(dungeonBaseLink, adapter.Position);
+                    phoneName = GetUnderwaterLabPhoneName(dungeonBaseLink, position);
                 }
 
-                var dynamicMonument = adapter.Monument as DynamicMonument;
+                var dynamicMonument = monument as DynamicMonument;
                 if (dynamicMonument != null)
                 {
                     phoneName = GetDynamicMonumentPhoneName(dynamicMonument, telephone);
@@ -3708,7 +3708,7 @@ namespace Oxide.Plugins
 
                 telephone.Controller.PhoneName = !string.IsNullOrEmpty(phoneName)
                     ? phoneName
-                    : $"{telephone.GetDisplayName()} {PhoneController.PositionToGridCoord(adapter.Position)}";
+                    : $"{telephone.GetDisplayName()} {PhoneController.PositionToGridCoord(position)}";
 
                 TelephoneManager.RegisterTelephone(telephone.Controller);
             }
@@ -3726,17 +3726,17 @@ namespace Oxide.Plugins
                 return $"{Tunnel} {tunnelName} {PhoneController.PositionToGridCoord(position)}";
             }
 
-            public static string GetFTLPhoneName(string tunnelAlias, DungeonGridCell dungeonGridCell, SingleEntityAdapter adapter, MonumentAddons plugin) 
+            public static string GetFTLPhoneName(string tunnelAlias, DungeonGridCell dungeonGridCell, BaseMonument monument, Vector3 position, MonumentAddons plugin) 
             {
                 var tunnelName = SplitCamelCase(tunnelAlias);
-                var phoneName = GetFTLCorridorPhoneName(tunnelName, adapter.Position);
+                var phoneName = GetFTLCorridorPhoneName(tunnelName, position);
 
-                if (adapter.Monument.AliasOrShortName == "TrainStation")
+                if (monument.AliasOrShortName == "TrainStation")
                 {
                     var attachedMonument = plugin._dungeonEntranceMapper.GetMonumentFromTunnel(dungeonGridCell);
                     if (attachedMonument != null && !attachedMonument.name.Contains("tunnel-entrance/entrance_bunker"))
                     {
-                        phoneName = GetFTLTrainStationPhoneName(attachedMonument, tunnelName, adapter.Position, plugin);
+                        phoneName = GetFTLTrainStationPhoneName(attachedMonument, tunnelName, position, plugin);
                     }
                 }
 
@@ -4646,7 +4646,7 @@ namespace Oxide.Plugins
                 var telephone = Entity as Telephone;
                 if (telephone != null && telephone.prefabID == 1009655496)
                 {
-                    PhoneUtils.NameTelephone(telephone, this, PluginInstance);
+                    PhoneUtils.NameTelephone(telephone, Monument, Position, PluginInstance);
                 }
 
                 if (EntityData.Scale != 1 || Entity.GetParentEntity() is SphereEntity)

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -3675,14 +3675,6 @@ namespace Oxide.Plugins
 
             private static readonly Regex SplitCamelCaseRegex = new Regex("([a-z])([A-Z])", RegexOptions.Compiled);
 
-            public static void RenameTelephone(PhoneController phone, string phoneName, Vector3 position, string monumentShortName, MonumentAddons plugin) 
-            {
-                if (ShouldAppendCoordinate(monumentShortName, plugin))
-                    phoneName += $" {PhoneController.PositionToGridCoord(position)}";
-
-                phone.PhoneName = phoneName;
-            }
-
             public static void NameTelephone(Telephone telephone, SingleEntityAdapter adapter, MonumentAddons plugin) 
             {
                 string phoneName = null;

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -3754,20 +3754,12 @@ namespace Oxide.Plugins
                 TelephoneManager.RegisterTelephone(telephone.Controller);
             }
 
-            public static string GetMonumentPhoneName(string phoneName, Vector3 position, string monumentShortName, MonumentHelper monumentHelper)
-            {
-                if (ShouldAppendCoordinate(monumentShortName, monumentHelper))
-                    phoneName += $" {PhoneController.PositionToGridCoord(position)}";
-
-                return phoneName;
-            }
-
-            public static string GetFTLCorridorPhoneName(string tunnelName, Vector3 position) 
+            private static string GetFTLCorridorPhoneName(string tunnelName, Vector3 position) 
             {
                 return $"{Tunnel} {tunnelName} {PhoneController.PositionToGridCoord(position)}";
             }
 
-            public static string GetFTLPhoneName(string tunnelAlias, DungeonGridCell dungeonGridCell, BaseMonument monument, Vector3 position, MonumentHelper monumentHelper) 
+            private static string GetFTLPhoneName(string tunnelAlias, DungeonGridCell dungeonGridCell, BaseMonument monument, Vector3 position, MonumentHelper monumentHelper) 
             {
                 var tunnelName = SplitCamelCase(tunnelAlias);
                 var phoneName = GetFTLCorridorPhoneName(tunnelName, position);
@@ -3784,7 +3776,7 @@ namespace Oxide.Plugins
                 return phoneName;
             }
 
-            public static string GetFTLTrainStationPhoneName(MonumentInfo attachedMonument, string tunnelName, Vector3 position, MonumentHelper monumentHelper) 
+            private static string GetFTLTrainStationPhoneName(MonumentInfo attachedMonument, string tunnelName, Vector3 position, MonumentHelper monumentHelper) 
             {
                 var phoneName = string.IsNullOrEmpty(attachedMonument.displayPhrase.translated) 
                     ? $"{Tunnel} {tunnelName}" 
@@ -3798,7 +3790,7 @@ namespace Oxide.Plugins
                 return phoneName;
             }
 
-            public static string GetUnderwaterLabPhoneName(DungeonBaseLink link, Vector3 position)
+            private static string GetUnderwaterLabPhoneName(DungeonBaseLink link, Vector3 position)
             {
                 var floors = link.Dungeon.Floors;
                 var gridCoordinate = PhoneController.PositionToGridCoord(position);
@@ -3819,7 +3811,7 @@ namespace Oxide.Plugins
                 return $"{UnderwaterLab} {gridCoordinate}";
             }
 
-            public static string GetDynamicMonumentPhoneName(DynamicMonument monument, Telephone phone)
+            private static string GetDynamicMonumentPhoneName(DynamicMonument monument, Telephone phone)
             {
                 if (monument.RootEntity is CargoShip)
                 {
@@ -3829,7 +3821,7 @@ namespace Oxide.Plugins
                 return $"{phone.GetDisplayName()} {monument.EntityId}";
             }
 
-            public static bool ShouldAppendCoordinate(string monumentShortName, MonumentHelper monumentHelper)
+            private static bool ShouldAppendCoordinate(string monumentShortName, MonumentHelper monumentHelper)
             {
                 if (PolymorphicMonumentVariants.Contains(monumentShortName))
                     return true;
@@ -3837,7 +3829,7 @@ namespace Oxide.Plugins
                 return !monumentHelper.IsMonumentUnique(monumentShortName);
             }
 
-            public static string SplitCamelCase(string camelCase)
+            private static string SplitCamelCase(string camelCase)
             {
                 return SplitCamelCaseRegex.Replace(camelCase, "$1 $2");
             }

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -3672,6 +3672,7 @@ namespace Oxide.Plugins
             public const string Tunnel = "FTL";
             public const string UnderwaterLab = "Underwater Lab";
             public const string CargoShip = "Cargo Ship";
+
             public static string GetMonumentPhoneName(MonumentInfo monument, bool isUnique, string gridCoordinate)
             {
                 var phoneName = monument.displayPhrase.translated;

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -3817,29 +3817,31 @@ namespace Oxide.Plugins
 
             public static bool ShouldAppendCoordinate(string monumentShortName, MonumentHelper monumentHelper)
             {
-                switch (monumentShortName)
+                string[] monumentVariants = 
                 {
-                    case "fishing_village_b":
-                    case "fishing_village_c":
-                    case "harbor_1":
-                    case "harbor_2":
-                    case "power_sub_big_1":
-                    case "power_sub_big_2":
-                    case "power_sub_small_1":
-                    case "power_sub_small_2":
-                    case "water_well_a":
-                    case "water_well_b":
-                    case "water_well_c":
-                    case "water_well_d":
-                    case "water_well_e":
-                    case "entrance_bunker_a":
-                    case "entrance_bunker_b":
-                    case "entrance_bunker_c":
-                    case "entrance_bunker_d":
-                        return true;
-                    default: 
-                        return !monumentHelper.IsMonumentUnique(monumentShortName);
-                }
+                    "fishing_village_b",
+                    "fishing_village_c",
+                    "harbor_1",
+                    "harbor_2",
+                    "power_sub_big_1",
+                    "power_sub_big_2",
+                    "power_sub_small_1",
+                    "power_sub_small_2",
+                    "water_well_a",
+                    "water_well_b",
+                    "water_well_c",
+                    "water_well_d",
+                    "water_well_e",
+                    "entrance_bunker_a",
+                    "entrance_bunker_b",
+                    "entrance_bunker_c",
+                    "entrance_bunker_d",
+                };
+
+                if (monumentVariants.Contains(monumentShortName))
+                    return true;
+
+                return !monumentHelper.IsMonumentUnique(monumentShortName);
             }
 
             public static string SplitCamelCase(string camelCase)

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -4243,7 +4243,7 @@ namespace Oxide.Plugins
             public override Vector3 Position => _transform.position;
             public override Quaternion Rotation => _transform.rotation;
 
-            private Regex _splitCamelCaseRegex = new Regex("([a-z])([A-Z])", RegexOptions.Compiled);
+            private static readonly Regex SplitCamelCaseRegex = new Regex("([a-z])([A-Z])", RegexOptions.Compiled);
 
             private BuildingGrade.Enum IntendedBuildingGrade
             {
@@ -4729,7 +4729,7 @@ namespace Oxide.Plugins
 
             private string SplitCamelCase(string camelCase)
             {
-                return _splitCamelCaseRegex.Replace(camelCase, "$1 $2");
+                return SplitCamelCaseRegex.Replace(camelCase, "$1 $2");
             }
         }
 

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -23,6 +23,7 @@ using CustomKillCallback = System.Action<UnityEngine.Component>;
 using CustomUpdateCallback = System.Action<UnityEngine.Component, Newtonsoft.Json.Linq.JObject>;
 using CustomAddDisplayInfoCallback = System.Action<UnityEngine.Component, Newtonsoft.Json.Linq.JObject, System.Text.StringBuilder>;
 using CustomSetDataCallback = System.Action<UnityEngine.Component, object>;
+using System.Text.RegularExpressions;
 
 namespace Oxide.Plugins
 {
@@ -4439,6 +4440,68 @@ namespace Oxide.Plugins
                         spooker.soundSpacingRand);
 
                     spooker.SetFlag(BaseEntity.Flags.Busy, true);
+                }
+
+                var telephone = Entity as Telephone;
+                if (telephone != null && telephone.prefabID == 1009655496)
+                {
+                    string phoneName = null;
+                    var gridCoodr = PhoneController.PositionToGridCoord(telephone.Controller.baseEntity.transform.position);
+
+                    var monumentInfo = Monument.Object as MonumentInfo;
+                    if (monumentInfo != null && !string.IsNullOrEmpty(monumentInfo.displayPhrase.translated))
+                    {
+                        phoneName = monumentInfo.displayPhrase.translated;
+
+                        var monuments = PluginInstance.FindMonumentsByShortName(Monument.ShortName);
+                        if (monuments != null && monuments.Count > 1)
+                        {
+                            phoneName += " " + gridCoodr;
+                        }
+                    }
+
+                    var dungeonGridCell = Monument.Object as DungeonGridCell;
+                    if (dungeonGridCell != null)
+                    {
+                        phoneName = "FTL " + Regex.Replace(Monument.AliasOrShortName, "([a-z])([A-Z])", "$1 $2");
+                        phoneName += " " + gridCoodr;
+                    }
+
+                    var dungeonBaseLink = Monument.Object as DungeonBaseLink;
+                    if (dungeonBaseLink != null)
+                    {
+                        var roomName = "";
+                        for (int i = 0; i < dungeonBaseLink.Dungeon.Floors.Count; i++)
+                        {
+                            if (dungeonBaseLink.Dungeon.Floors[i].Links.Contains(dungeonBaseLink))
+                            {
+                                roomName = " L" + (i + 1) + " " + dungeonBaseLink.Type.ToString() + " " + dungeonBaseLink.Dungeon.Floors[i].Links.IndexOf(dungeonBaseLink);
+                                break;
+                            }
+                        }
+
+                        phoneName = "Underwater Lab " + gridCoodr + roomName;
+                    }
+
+                    var dynamicMonument = Monument as DynamicMonument;
+                    if (dynamicMonument != null)
+                    {
+                        if (dynamicMonument.RootEntity.ShortPrefabName == "cargoshiptest")
+                        {
+                            phoneName = "Cargo Ship " + dynamicMonument.EntityId;
+                        }
+                        else 
+                        {
+                            phoneName = telephone.GetDisplayName() + " " + dynamicMonument.EntityId;
+                        }
+                    }
+
+                    if (phoneName != null)
+                        telephone.Controller.PhoneName = phoneName;
+                    else 
+                        telephone.Controller.PhoneName = telephone.GetDisplayName() + " " + gridCoodr;
+
+                    TelephoneManager.RegisterTelephone(telephone.Controller);
                 }
 
                 if (EntityData.Scale != 1 || Entity.GetParentEntity() is SphereEntity)


### PR DESCRIPTION
#29 

**Monuments**
 - if there is `displayPhrase` in `MonumentInfo`, show it as telephone name (**Abandoned Cabins**)
   - some **difference** in certain vanilla telephone vs landmark name (Satellite Dish Array vs **Satellite Dish**)
 - append grid coords if multiple instances of same monument (**Substation G12**)
 - when there is no `displayPhrase` in `MonumentInfo` (cave_large_sewers_hard), name will be just `telephone.GetDisplayName()`+ coord (**Telephone G12**)

**Freight Transit Line**
 - Utilizing aliases + grid coord with FTL prefix
   - **FTL Train Station G12**
   - **FTL Large Intersection F23**
   - **FTL Corner Tunnel R7**

**Underwater Labs**
 - I couldn't figure how to get "Underwater Lab" string from game, so I hardcoded it for now
 - Underwater Lab + grid coord + level index + room type + room index
   - **Underwater Lab X1 L4 Room 1**
   - **Underwater Lab X1 L1 Corridor 7**
  
I am not sure if `DoServerDestroy()` is called on `Telephone` instance when unloading MA. If not, we should add `TelephoneManager.DeregisterTelephone(phoneController)` to `PreEntityKill()`

I feel like code needs some improvements, but im pretty happy with functional result

Edit: Added dynamic monuments support