### PR TITLE
disabled decay for hackcrates, reenabling it after hack complete

### DIFF
--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -5197,6 +5197,13 @@ namespace Oxide.Plugins
                     SpawnedVehicleComponent.AddToVehicle(Adapter.PluginInstance, instance.gameObject);
                     entity.Invoke(() => DisableVehicleDecay(entity), 5);
                 }
+
+                if (entity is HackableLockedCrate hackableCrate && hackableCrate.shouldDecay)
+                {
+                    hackableCrate.shouldDecay = false;
+                    hackableCrate.CancelInvoke(hackableCrate.DelayedDestroy);
+                    hackableCrate.InvokeRepeating(() => SetHackableCrateDecay(hackableCrate), UnityEngine.Random.Range(0f, 5f), 300f);
+                }
             }
 
             public override void ObjectRetired(SpawnPointInstance instance)
@@ -5320,6 +5327,18 @@ namespace Oxide.Plugins
                     return;
                 }
             }
+
+            private void SetHackableCrateDecay(HackableLockedCrate hackableCrate)
+            {
+                if (hackableCrate == null)
+                    return;
+
+                if (hackableCrate.shouldDecay || !hackableCrate.HasFlag(HackableLockedCrate.Flag_FullyHacked))
+                    return;
+
+                hackableCrate.shouldDecay = true;
+                hackableCrate.RefreshDecay();
+            }   
         }
 
         private class CustomSpawnGroup : SpawnGroup

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -5198,7 +5198,8 @@ namespace Oxide.Plugins
                     entity.Invoke(() => DisableVehicleDecay(entity), 5);
                 }
 
-                if (entity is HackableLockedCrate hackableCrate && hackableCrate.shouldDecay)
+                var hackableCrate = entity as HackableLockedCrate;
+                if ((object)hackableCrate != null && hackableCrate.shouldDecay)
                 {
                     hackableCrate.shouldDecay = false;
                     hackableCrate.CancelInvoke(hackableCrate.DelayedDestroy);

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -5203,7 +5203,6 @@ namespace Oxide.Plugins
                 {
                     hackableCrate.shouldDecay = false;
                     hackableCrate.CancelInvoke(hackableCrate.DelayedDestroy);
-                    hackableCrate.InvokeRepeating(() => SetHackableCrateDecay(hackableCrate), UnityEngine.Random.Range(0f, 5f), 300f);
                 }
             }
 
@@ -5328,18 +5327,6 @@ namespace Oxide.Plugins
                     return;
                 }
             }
-
-            private void SetHackableCrateDecay(HackableLockedCrate hackableCrate)
-            {
-                if (hackableCrate == null)
-                    return;
-
-                if (hackableCrate.shouldDecay || !hackableCrate.HasFlag(HackableLockedCrate.Flag_FullyHacked))
-                    return;
-
-                hackableCrate.shouldDecay = true;
-                hackableCrate.RefreshDecay();
-            }   
         }
 
         private class CustomSpawnGroup : SpawnGroup


### PR DESCRIPTION
#36 

- disabled decay on hackable crates
- added repeating check if hack crate is fully hacked every 5 minutes. If crate is fully hacked, re-enable decay timer to make sure  crate will despawn when players leave some loot inside