### PR TITLE
implemented skull trophies logic, api

### DIFF
--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -748,7 +748,8 @@ namespace Oxide.Plugins
             if (!VerifyLookingAtAdapter(player, out adapter, out controller, LangEntry.ErrorNoSuitableAddonFound))
                 return;
 
-            if (!controller.EntityData.PrefabName.Contains("assets/prefabs/misc/halloween/trophy skulls/"))
+            var skullTrophy = adapter.Entity as SkullTrophy;
+            if (skullTrophy == null)
             {
                 ReplyToPlayer(player, LangEntry.ErrorNoSuitableAddonFound);
                 return;
@@ -5492,7 +5493,8 @@ namespace Oxide.Plugins
 
                 var skull = ItemManager.CreateByPartialName("skull.human");
                 skull.name = HumanBodyResourceDispenser.CreateSkullName(skullName);
-                skullTrophy.inventory.Insert(skull);
+                if (!skull.MoveToContainer(skullTrophy.inventory))
+                    skull.Remove();
 
                 // Setting flag here so vanilla functionality is preserved for trophies without name set
                 skullTrophy.SetFlag(BaseEntity.Flags.Busy, true);
@@ -10630,7 +10632,7 @@ namespace Oxide.Plugins
             public static readonly LangEntry CCTVSetIdSuccess = new LangEntry("CCTV.SetId.Success2", "Updated CCTV id to <color=#fd4>{0}</color> at <color=#fd4>{1}</color> matching monument(s) and saved to profile <color=#fd4>{2}</color>.");
             public static readonly LangEntry CCTVSetDirectionSuccess = new LangEntry("CCTV.SetDirection.Success2", "Updated CCTV direction at <color=#fd4>{0}</color> matching monument(s) and saved to profile <color=#fd4>{1}</color>.");
 
-            public static readonly LangEntry SkullNameSyntax = new LangEntry("SkullName.Syntax", "Syntax: <color=#fd4>{0} <skull name></color>");
+            public static readonly LangEntry SkullNameSyntax = new LangEntry("SkullName.Syntax", "Syntax: <color=#fd4>{0} <name></color>");
             public static readonly LangEntry SkullNameSetSuccess = new LangEntry("SkullName.Set.Success", "Updated skull name to <color=#fd4>{0}</color> at <color=#fd4>{1}</color> matching monument(s) and saved to profile <color=#fd4>{2}</color>.");
 
             public static readonly LangEntry ProfileListEmpty = new LangEntry("Profile.List.Empty", "You have no profiles. Create one with <color=#fd4>maprofile create <name></maprofile>");

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -2379,13 +2379,13 @@ namespace Oxide.Plugins
             sb.AppendLine(GetMessage(player.Id, LangEntry.HelpSkin));
             sb.AppendLine(GetMessage(player.Id, LangEntry.HelpSetId));
             sb.AppendLine(GetMessage(player.Id, LangEntry.HelpSetDir));
+            sb.AppendLine(GetMessage(player.Id, LangEntry.HelpSkull));
             sb.AppendLine(GetMessage(player.Id, LangEntry.HelpSpawnGroup));
             sb.AppendLine(GetMessage(player.Id, LangEntry.HelpSpawnPoint));
             sb.AppendLine(GetMessage(player.Id, LangEntry.HelpPaste));
             sb.AppendLine(GetMessage(player.Id, LangEntry.HelpShow));
             sb.AppendLine(GetMessage(player.Id, LangEntry.HelpShowVanilla));
             sb.AppendLine(GetMessage(player.Id, LangEntry.HelpProfile));
-            sb.AppendLine(GetMessage(player.Id, LangEntry.HelpSkull));
             player.Reply(sb.ToString());
         }
 

--- a/MonumentAddons.cs
+++ b/MonumentAddons.cs
@@ -10713,7 +10713,7 @@ namespace Oxide.Plugins
             public static readonly LangEntry HelpPaste = new LangEntry("Help.Paste", "<color=#fd4>mapaste <file></color> - Paste a building");
             public static readonly LangEntry HelpShow = new LangEntry("Help.Show", "<color=#fd4>mashow</color> - Show nearby addons");
             public static readonly LangEntry HelpShowVanilla = new LangEntry("Help.ShowVanilla", "<color=#fd4>mashowvanilla</color> - Show vanilla spawn points");
-            public static readonly LangEntry HelpProfile = new LangEntry("Help.Profile", "<color=#fd4>maprofile</color> - Print profile help");        
+            public static readonly LangEntry HelpProfile = new LangEntry("Help.Profile", "<color=#fd4>maprofile</color> - Print profile help");
 
             public string Name;
             public string English;


### PR DESCRIPTION
#37 

Hello again,

since server owners most likely want to display names of their supporters or top ranks from leaderboars (without hunting them around for skulls), I implemented `maskull` command with `skullName` argument. Also I couldn't think of another situation, where container persistence could be beneficial. Vehicles could be sorted out by another plugins and only interesting use case to me are very custom lootboxes (fridges with food, large boxes with resources like stone, metal, etc) as another loot source for players, but that would require some extra steps. All that sounds more like custom addon than something MA should support by default, imo.

Changes:
 - added `SkullName` field to `SingeEntityController` data
 - added command `maskull` to attach named skull and set trophy as busy (without command, skull can be added/removed manually)
 - ensure skull is atached on spawn, when data contains skull name
 - added api to change skull name externally

API
While this solution works just fine, I am not sure if it isn't too specific - I think profile data could be manipulated in more general way, but im not sure how to approach it. What do you think?
Motivation for this method is automation of throphy names display based on variable data