### PR TITLE
Add two new profiles

### DIFF
--- a/Profiles/MonumentCooking.json
+++ b/Profiles/MonumentCooking.json
@@ -1,0 +1,271 @@
+{
+  "Name": "MonumentCooking",
+  "Author": "HunterZ",
+  "SchemaVersion": 2.0,
+  "MonumentData": {
+    "bandit_town": {
+      "Entities": [
+        {
+          "Id": "6be38c46-8aeb-4ca6-9275-393e262907fa",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": 66.0,
+            "y": 2.0,
+            "z": -46.5
+          }
+        }
+      ]
+    },
+    "fishing_village_a": {
+      "Entities": [
+        {
+          "Id": "528e4d0a-3e1c-408d-a0cc-43daa37e3b3f",
+          "PrefabName": "assets/bundled/prefabs/static/bbq.static.prefab",
+          "Position": {
+            "x": -16.0,
+            "y": 2.0,
+            "z": 10.0
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 90.0,
+            "z": 0.0
+          }
+        }
+      ]
+    },
+    "fishing_village_b": {
+      "Entities": [
+        {
+          "Id": "22fe9234-bdc7-43bd-adfc-6e09230ccbac",
+          "PrefabName": "assets/bundled/prefabs/static/bbq.static.prefab",
+          "Position": {
+            "x": -2.3,
+            "y": 2.0,
+            "z": 8.0
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 180.0,
+            "z": 0.0
+          }
+        }
+      ]
+    },
+    "fishing_village_c": {
+      "Entities": [
+        {
+          "Id": "d043c39d-e019-4435-a59b-a79f5e5cc04a",
+          "PrefabName": "assets/bundled/prefabs/static/bbq.static.prefab",
+          "Position": {
+            "x": 10.5,
+            "y": 2.01,
+            "z": 7.5
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 180.0,
+            "z": 0.0
+          }
+        }
+      ]
+    },
+    "harbor_1": {
+      "Entities": [
+        {
+          "Id": "ad0117b5-71c5-4f2f-bd5e-e3a1bcc72006",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": 94.0,
+            "y": 2.25,
+            "z": -7.0
+          }
+        }
+      ]
+    },
+    "harbor_2": {
+      "Entities": [
+        {
+          "Id": "fd1baad0-1bc5-4c3a-a015-56fb8700a7eb",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": 35.0,
+            "y": 2.1,
+            "z": -70.0
+          }
+        }
+      ]
+    },
+    "junkyard_1": {
+      "Entities": [
+        {
+          "Id": "9d13bef0-e973-48fd-91a7-a2db9c41cb81",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": -20.0,
+            "y": 4.57,
+            "z": -21.5
+          }
+        }
+      ]
+    },
+    "lighthouse": {
+      "Entities": [
+        {
+          "Id": "4bd0a5a8-4f4e-4c12-85c1-3d4ebdb36ce5",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": -2.1,
+            "y": 14.0,
+            "z": -1.2
+          }
+        }
+      ]
+    },
+    "mining_quarry_a": {
+      "Entities": [
+        {
+          "Id": "71519cc6-2ed4-4ca9-8b6b-7d43462a3515",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": -16.0,
+            "y": 3.21,
+            "z": -10.5
+          }
+        }
+      ]
+    },
+    "mining_quarry_b": {
+      "Entities": [
+        {
+          "Id": "71972008-fc93-4510-aba8-b8a3b97c28ab",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": 4.8,
+            "y": -0.01,
+            "z": 9.0
+          }
+        }
+      ]
+    },
+    "mining_quarry_c": {
+      "Entities": [
+        {
+          "Id": "b053c173-b08e-4c45-96aa-3cd01414ca5e",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": -15.0,
+            "y": 3.09,
+            "z": 30.0
+          }
+        }
+      ]
+    },
+    "radtown_small_3": {
+      "Entities": [
+        {
+          "Id": "45d81d21-4137-4a24-94f6-d4ba602f5543",
+          "PrefabName": "assets/bundled/prefabs/static/campfire_static.prefab",
+          "Position": {
+            "x": -35.0,
+            "y": 19.75,
+            "z": -49.0
+          }
+        }
+      ]
+    },
+    "satellite_dish": {
+      "Entities": [
+        {
+          "Id": "f7d6fdda-0059-455e-951b-e1fe94d43e39",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": 1.0,
+            "y": 6.02,
+            "z": 4.0
+          }
+        }
+      ]
+    },
+    "sphere_tank": {
+      "Entities": [
+        {
+          "Id": "7d9ae19f-eae5-49d6-bdec-e6bb765c0aaf",
+          "PrefabName": "assets/bundled/prefabs/static/hobobarrel_static.prefab",
+          "Position": {
+            "x": -2.8,
+            "y": 5.87,
+            "z": -6.5
+          }
+        }
+      ]
+    },
+    "stables_a": {
+      "Entities": [
+        {
+          "Id": "483830f7-e2c5-40bb-bd60-e1931dd9ec1f",
+          "PrefabName": "assets/bundled/prefabs/static/bbq.static.prefab",
+          "Position": {
+            "x": -13.5,
+            "y": 3.01,
+            "z": -8.0
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 180.0,
+            "z": 0.0
+          }
+        }
+      ]
+    },
+    "stables_b": {
+      "Entities": [
+        {
+          "Id": "7e698d3e-6242-461f-a446-28732f73c8e3",
+          "PrefabName": "assets/bundled/prefabs/static/bbq.static.prefab",
+          "Position": {
+            "x": 13.0,
+            "y": 2.99,
+            "z": -4.8
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 90.0,
+            "z": 0.0
+          }
+        }
+      ]
+    },
+    "swamp_c": {
+      "Entities": [
+        {
+          "Id": "36c8e2d5-00ef-4d77-b22d-476602716bf0",
+          "PrefabName": "assets/bundled/prefabs/static/bbq.static.prefab",
+          "Position": {
+            "x": 0.75,
+            "y": 1.14,
+            "z": -34.5
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 205.0,
+            "z": 0.0
+          }
+        }
+      ]
+    },
+    "warehouse": {
+      "Entities": [
+        {
+          "Id": "c923897b-f795-40c6-9b88-e02bf6cc1816",
+          "PrefabName": "assets/bundled/prefabs/static/campfire_static.prefab",
+          "Position": {
+            "x": -19.0,
+            "y": 0.0,
+            "z": -10.0
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Profiles/SafeZoneRecyclers.json
+++ b/Profiles/SafeZoneRecyclers.json
@@ -1,0 +1,92 @@
+{
+  "Name": "SafeZoneRecyclers",
+  "Author": "HunterZ",
+  "SchemaVersion": 2.0,
+  "MonumentData": {
+    "fishing_village_a": {
+      "Entities": [
+        {
+          "Id": "cc7bb6ff-fc4c-4bd2-b309-e273e0852f03",
+          "PrefabName": "assets/bundled/prefabs/static/recycler_static.prefab",
+          "Position": {
+            "x": -20.0,
+            "y": 2.066,
+            "z": -19.6
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 94.7,
+            "z": 0.0
+          }
+        }
+      ]
+    },
+    "fishing_village_b": {
+      "Entities": [
+        {
+          "Id": "c9614658-f9f7-4b73-aef0-89b643c56be1",
+          "PrefabName": "assets/bundled/prefabs/static/recycler_static.prefab",
+          "Position": {
+            "x": -6.75,
+            "y": 2.075,
+            "z": 5.4
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 90.0,
+            "z": 0.0
+          }
+        }
+      ]
+    },
+    "fishing_village_c": {
+      "Entities": [
+        {
+          "Id": "b28cd901-a45e-4c23-bb6a-4610308f5647",
+          "PrefabName": "assets/bundled/prefabs/static/recycler_static.prefab",
+          "Position": {
+            "x": -7.35,
+            "y": 2.086,
+            "z": -8.25
+          }
+        }
+      ]
+    },
+    "stables_a": {
+      "Entities": [
+        {
+          "Id": "5e031220-f573-410f-97ab-59326777498c",
+          "PrefabName": "assets/bundled/prefabs/static/recycler_static.prefab",
+          "Position": {
+            "x": -2.67,
+            "y": 3.26,
+            "z": -14.25
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 180.0,
+            "z": 0.0
+          }
+        }
+      ]
+    },
+    "stables_b": {
+      "Entities": [
+        {
+          "Id": "ae774a75-8e8f-4dac-9b3e-ec9015fa2721",
+          "PrefabName": "assets/bundled/prefabs/static/recycler_static.prefab",
+          "Position": {
+            "x": 1.5,
+            "y": 3.15,
+            "z": -4.5
+          },
+          "RotationAngles": {
+            "x": 0.0,
+            "y": 180.0,
+            "z": 0.0
+          }
+        }
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -54,14 +54,16 @@ Let's face it, you are probably planning to use this plugin the same way as many
 
 Several example profiles are included below. Run the corresponding command snippet to install each profile.
 
-- `mainstall OutpostAirwolf` -- Adds an Air Wolf vendor to Outpost, with some ladders to allow access.
 - `mainstall BarnAirwolf` -- Adds an Air Wolf vendor to Large Barn and Ranch.
+- `mainstall CargoShipCCTV` -- Adds 7 CCTVs and one computer station to cargo ship (same as the Cargo Ship CCTV plugin).
 - `mainstall FishingVillageAirwolf` -- Adds an Air Wolf vendor to Large Fishing Village and to one of the small Fishing Villages.
+- `mainstall MonumentCooking` -- Adds a cooking static (BBQ / camp fire / hobo barrel) to safe zones and low-level named monuments that lack them.
 - `mainstall MonumentLifts` -- Adds car lifts to gas station and supermarket (same as the MonumentLifts plugin).
 - `mainstall MonumentsRecycler` -- Adds recyclers to Cargo Ship, Oilrigs, Dome and Fishing Villages (same as the MonumentsRecycler plugin).
-- `mainstall TrainStationCCTV` -- Adds 6 CCTVs and one computer station to each underground Train Station.
-- `mainstall CargoShipCCTV` -- Adds 7 CCTVs and one computer station to cargo ship (same as the Cargo Ship CCTV plugin).
 - `mainstall OilRigSharks` -- Adds one shark to small rig and two sharks to lage rig.
+- `mainstall OutpostAirwolf` -- Adds an Air Wolf vendor to Outpost, with some ladders to allow access.
+- `mainstall SafeZoneRecyclers` -- Adds a recycler to Fishing Villages, Large Barn, and Ranch (different locations than MonumentsRecycler for compatibility).
+- `mainstall TrainStationCCTV` -- Adds 6 CCTVs and one computer station to each underground Train Station.
 
 These example profiles are installed from https://github.com/WheteThunger/MonumentAddons/blob/master/Profiles/.
 Don't see what you're looking for? Want to showcase a profile you created? Fork the repository on [GitHub](https://github.com/WheteThunger/MonumentAddons), commit the changes, and submit a pull request!


### PR DESCRIPTION
Created two new profiles:

MonumentCooking:
 - Effect: Adds a BBQ, campfire, or hobo barrel to Bandit Camp, Fishing Villages, Harbors, Junkyard, Lighthouses, Mining Quarries, Sewer Branch, Satellite Dish, The Dome, Large Barn, Ranch, Abandoned Cabins, and Mining Outposts
 - Rationale: I don't like the inconsistency in vanilla that some safe zones (Outpost) and low-level monuments (gas stations, supermarkets, etc.) have cooking facilities and some don't, nor that some monuments have perpetually-burning hobo barrels that provide comfort but cannot be used for cooking. Also, falling into the frigid waters of an arctic Harbor can be a death sentence!

SafeZoneRecyclers:
- Effect: Adds a recycler to Fishing Villages, Large Barn, and Ranch. Fishing Village locations are different from MonumentsRecycler, so that they will not conflict if both are enabled
- Rationale: I don't t like that MonumentsRecycler adds to both safe zones and PvP monuments, nor that it leaves out Barn/Ranch. I also find some of MonumentsRecycler's Fishing Village placements odd.